### PR TITLE
Add a helper method to enable/disable plugins during staging of Eiger detectors

### DIFF
--- a/startup/20-area-detectors.py
+++ b/startup/20-area-detectors.py
@@ -239,6 +239,21 @@ class EigerBaseV33(EigerBase):
     stats4 = Cpt(StatsPluginV33, 'Stats4:')
     stats5 = Cpt(StatsPluginV33, 'Stats5:')
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._plugins_to_enable_or_disable = \
+                [f'roi{i}' for i in range(1, 4+1)] + \  # roi1..4
+                [f'stats{i}' for i in range(1, 5+1)] + \  # stats1..5
+                ['proc1', 'image']
+        self._plugins_stage_sigs = OrderedDict([('enable', 1),
+                                                ('blocking_callbacks', 'No'),
+                                                ('parent.cam.array_callbacks', 1)])
+
+    def enable_plugins(self, enable=True):
+        self._plugins_stage_sigs['enable'] = 1 if enable else 0
+        for cpt in self._plugins_to_enable_or_disable:
+            getattr(self, cpt).stage_sigs = self._plugins_stage_sigs
+
 
 class EigerSingleTrigger(SingleTrigger, EigerBase):
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
During today's CHX visit with @oksanagit, @jklynch, @AbbyGi, @MikeHart85 over zoom and Lutz in person, we tried this method to disable plugins during the staging process of the `eiger1m_single` detector to speed up the acquisition process:
```py
for i in range(1, 4+1):
    getattr(eiger1m_single, f'roi{i}').stage_sigs = OrderedDict([('enable', 0),
             ('blocking_callbacks', 'No'),
             ('parent.cam.array_callbacks', 1)])

for i in range(1, 5+1):
    getattr(eiger1m_single, f'stats{i}').stage_sigs = OrderedDict([('enable', 0),
             ('blocking_callbacks', 'No'),
             ('parent.cam.array_callbacks', 1)])

eiger1m_single.proc1.stage_sigs = OrderedDict([('enable', 0),
             ('blocking_callbacks', 'No'),
             ('parent.cam.array_callbacks', 1)])

eiger1m_single.image.stage_sigs = OrderedDict([('enable', 0),
             ('blocking_callbacks', 'No'),
             ('parent.cam.array_callbacks', 1)])
```

We also figured out the non-blocking plugin mode was only enabled for `eiger4m_single`, but not for the other 2 detectors (`eiger500k_single` and `eiger1m_single`). https://github.com/NSLS-II-CHX/profile_collection/commit/de6e03125a16f27f87cbce245bf355a2b783ebdc resolved it. We did a few tests with manipulation of the `['roi1', 'roi2', 'roi3', 'roi4', 'stats1', 'stats2', 'stats3', 'stats4', 'stats5', 'proc1', 'image']` plugins, and the results are as follows:
- all plugins enabled/blocking mode: 2000 frames with 0.001 s/frame took ~20s;
- all plugins enabled/non-blocking mode: 2000 frames with 0.001 s/frame took ~9s on the first run after `bsui` restart, and ~6.8s for the subsequent runs;
- all plugins disabled/non-blocking mode: 2000 frames with 0.001 s/frame took ~9s on the first run after `bsui` restart, and ~6.8s for the subsequent runs.

The last 2 cases were comparable in terms of the speed of the scan, but when all plugins are enabled/non-blocking, the resource use is significantly higher than when the plugins are disabled. So, the current PR's update is to provide a way to disable the plugins when needed (they are enabled by default).

Usage:
```py
eiger1m_single.enable_plugins()  # to enable the plugins
eiger1m_single.enable_plugins(enable=False)  # to disable the plugins
```

This needs to be tested thoroughly before going to production, preferably with the beam.